### PR TITLE
i3ipc-python-git: remove unecessary depends

### DIFF
--- a/i3ipc/i3ipc-python-git/PKGBUILD
+++ b/i3ipc/i3ipc-python-git/PKGBUILD
@@ -7,7 +7,7 @@ arch=('any')
 url='https://github.com/acrisci/i3ipc-python'
 license=('custom:BSD')
 
-depends=('python' 'i3ipc-glib' 'python-xlib' 'python2-enum34')
+depends=('python' 'python-xlib')
 makedepends=('git' 'python-setuptools')
 provides=('i3ipc-python')
 conflicts=('i3ipc-python')


### PR DESCRIPTION
i3ipc-glib is not required for i3ipc-python.

python2-enum34 is only required for python < 3.4