### PR TITLE
Remove now obsolete dependency

### DIFF
--- a/i3ipc/i3ipc-python-git/PKGBUILD
+++ b/i3ipc/i3ipc-python-git/PKGBUILD
@@ -7,7 +7,7 @@ arch=('any')
 url='https://github.com/acrisci/i3ipc-python'
 license=('custom:BSD')
 
-depends=('python' 'python-xlib')
+depends=('python')
 makedepends=('git' 'python-setuptools')
 provides=('i3ipc-python')
 conflicts=('i3ipc-python')


### PR DESCRIPTION
python-xlib is obsolete since acrisci/i3ipc-python#28 got merged