### PR TITLE
Fix gpu not supported

### DIFF
--- a/shotcut/shotcut-git/PKGBUILD
+++ b/shotcut/shotcut-git/PKGBUILD
@@ -18,6 +18,7 @@ depends=(
     'qt5-websockets'
     'qt5-x11extras'
     'mlt-git'
+    'movit'
     'ffmpeg'
     'libx264'
     'libvpx'

--- a/shotcut/shotcut/PKGBUILD
+++ b/shotcut/shotcut/PKGBUILD
@@ -19,6 +19,7 @@ depends=(
     'qt5-websockets'
     'qt5-x11extras'
     'mlt'
+    'movit'
     'ffmpeg'
     'libx264'
     'libvpx'


### PR DESCRIPTION
It fixes this error.
`[Warning] <MLT> mlt_repository_init: failed to dlopen /usr/lib/mlt/libmltopengl.so  (libmovit.so.6: cannot open shared object file: No such file or directory)`