### PR TITLE
make shotcut build use ${C,CXX}FLAGS

### DIFF
--- a/qt5-styleplugins/qt5-styleplugins-git/PKGBUILD
+++ b/qt5-styleplugins/qt5-styleplugins-git/PKGBUILD
@@ -2,8 +2,8 @@
 pkgname=('qt5-styleplugins-git')
 _srcname='qtstyleplugins'
 pkgdesc='Additional style plugins for Qt5'
-pkgver='r28'
-pkgrel='2'
+pkgver='r36'
+pkgrel='1'
 arch=('i686' 'x86_64')
 url="https://code.qt.io/cgit/qt/${_srcname}"
 license=('LGPL')
@@ -28,7 +28,10 @@ pkgver() {
 build() {
     cd "${srcdir}/${_srcname}"
 
-    qmake PREFIX='/usr' LIBDIR='/usr/lib'
+    qmake PREFIX='/usr' \
+        LIBDIR='/usr/lib' \
+        QMAKE_CFLAGS_RELEASE="${CFLAGS}" \
+        QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}"
     make
 }
 

--- a/qt5-styleplugins/qt5-styleplugins/PKGBUILD
+++ b/qt5-styleplugins/qt5-styleplugins/PKGBUILD
@@ -4,7 +4,7 @@ _srcname='qtstyleplugins'
 pkgdesc='Additional style plugins for Qt5'
 pkgver='5.0.0'
 _commit='84b443109729664c7a0bd124b42c493f28069efc'
-pkgrel='9'
+pkgrel='10'
 arch=('i686' 'x86_64')
 url="https://code.qt.io/cgit/qt/${_srcname}"
 license=('LGPL')
@@ -22,7 +22,10 @@ install='install.sh'
 build() {
     cd "${srcdir}/${_srcname}"
 
-    qmake PREFIX='/usr' LIBDIR='/usr/lib'
+    qmake PREFIX='/usr' \
+        LIBDIR='/usr/lib' \
+        QMAKE_CFLAGS_RELEASE="${CFLAGS}" \
+        QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}"
     make
 }
 

--- a/shotcut/shotcut-git/PKGBUILD
+++ b/shotcut/shotcut-git/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=('shotcut-git')
 _srcname='shotcut'
 pkgdesc='Video editor'
-pkgver='r2117'
+pkgver='r2235'
 pkgrel='1'
 arch=('i686' 'x86_64')
 url='https://github.com/mltframework/shotcut'
@@ -59,7 +59,9 @@ prepare() {
 build() {
     cd "${srcdir}/${_srcname}"
 
-    qmake PREFIX='/usr/'
+    qmake PREFIX='/usr' \
+        QMAKE_CFLAGS_RELEASE="${CFLAGS}" \
+        QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}"
     make
 }
 

--- a/shotcut/shotcut/PKGBUILD
+++ b/shotcut/shotcut/PKGBUILD
@@ -4,7 +4,7 @@ _srcname='shotcut'
 pkgdesc='Video editor'
 pkgver='17.06'
 _commit='b38ae67876faf6764550f38690f7f2684e5f1dd3'
-pkgrel='1'
+pkgrel='2'
 arch=('i686' 'x86_64')
 url='https://www.shotcut.org/'
 license=('GPL3')
@@ -51,7 +51,9 @@ prepare() {
 build() {
     cd "${srcdir}/${_srcname}"
 
-    qmake PREFIX='/usr/'
+    qmake PREFIX='/usr' \
+        QMAKE_CFLAGS_RELEASE="${CFLAGS}" \
+        QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}"
     make
 }
 


### PR DESCRIPTION
just something I  happen to stumble upon while makeing `shotcut`,

qmake autosets CXXFLAGS , I think it would be better to use the systems settings with the method menitoned in the [wiki](https://wiki.archlinux.org/index.php/makepkg#CFLAGS.2FCXXFLAGS.2FCPPFLAGS_in_makepkg.conf_do_not_work_for_QMAKE_based_packages);

This is a PR to demo the change (I assume there are other PKGBUILDS which could be adjusted in the same manner), I do not insist on merging it if you don't want it.
