### PR TITLE
Fix the borken waifu2-converter-cpp.

### DIFF
--- a/waifu2x-converter-cpp/waifu2x-converter-cpp-git/PKGBUILD
+++ b/waifu2x-converter-cpp/waifu2x-converter-cpp-git/PKGBUILD
@@ -32,7 +32,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX='/usr' \
         -DCMAKE_BUILD_TYPE='Release' \
         -DINSTALL_MODELS='ON' \
-        -DOVERRIDE_OPENCV='ON' \
+        -DOPENCV_PREFIX='/usr' \
         .
     make
 }


### PR DESCRIPTION
CMakeLists.txt of the upstream repo was updated several days ago and the lines for OVERRIDE_OPENCV were commented out, so cmake can longer no find the location of opencv. Settings OPENCV_PREFIX should fix the problem.

https://github.com/DeadSix27/waifu2x-converter-cpp/blob/2f8e483bf82e279bf3f05caba45de2d00d0fc4d2/CMakeLists.txt#L31-L37