### PR TITLE
Shotcut: set version to pkgver.

### DIFF
--- a/shotcut/shotcut/PKGBUILD
+++ b/shotcut/shotcut/PKGBUILD
@@ -53,7 +53,8 @@ build() {
 
     qmake PREFIX='/usr' \
         QMAKE_CFLAGS_RELEASE="${CFLAGS}" \
-        QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}"
+        QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}" \
+        SHOTCUT_VERSION="${pkgver}"
     make
 }
 


### PR DESCRIPTION
During qmake execution, if `SHOTCUT_VERSION` is not defined, the current date is used, which is then displayed in the About Shotcut dialog. This PR sets `SHOTCUT_VERSION` to `pkgver` so the user knows which version is being used.