### PR TITLE
Shotcut: do not install additional .desktop file.

### DIFF
--- a/shotcut/shotcut/PKGBUILD
+++ b/shotcut/shotcut/PKGBUILD
@@ -61,6 +61,4 @@ package() {
     cd "${srcdir}/${_srcname}"
 
     make INSTALL_ROOT="${pkgdir}" install
-
-    install -D --mode=644 "${srcdir}/shotcut.desktop" "${pkgdir}/usr/share/applications/shotcut.desktop"
 }

--- a/shotcut/shotcut/PKGBUILD
+++ b/shotcut/shotcut/PKGBUILD
@@ -33,11 +33,9 @@ conflicts=("${pkgname[0]%-git}")
 
 source=(
     "${_srcname}::git+https://github.com/mltframework/shotcut.git#commit=${_commit}"
-    'shotcut.desktop'
     'melt.patch'
 )
 sha512sums=(
-    'SKIP'
     'SKIP'
     'SKIP'
 )

--- a/shotcut/shotcut/shotcut.desktop
+++ b/shotcut/shotcut/shotcut.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Shotcut
-GenericName=Video Editor
-Comment=Video editor
-Exec=shotcut
-Icon=applications-multimedia
-Terminal=false
-Categories=AudioVideo;Video;AudioVideoEditing;


### PR DESCRIPTION
Shotcut provides it's own desktop file and the inclusion of this one is confusing.