### PR TITLE
build and install translations

### DIFF
--- a/shotcut/shotcut/PKGBUILD
+++ b/shotcut/shotcut/PKGBUILD
@@ -54,10 +54,14 @@ build() {
         QMAKE_CXXFLAGS_RELEASE="${CXXFLAGS}" \
         SHOTCUT_VERSION="${pkgver}"
     make
+    cd translations
+    lrelease *.ts
+
 }
 
 package() {
     cd "${srcdir}/${_srcname}"
 
     make INSTALL_ROOT="${pkgdir}" install
+    install -Dm644 translations/*.qm -t "$pkgdir"/usr/share/${_srcname}/translations/
 }


### PR DESCRIPTION
The upstream project advertizes their translations in many languages, but do not deliver a way for packagers to actually provide them. This Patch xcicumvents this by providing them manually.