### PR TITLE
Renamed iwpmd to libiwpm in _provides.

### DIFF
--- a/infiniband/rdma-core-git/PKGBUILD
+++ b/infiniband/rdma-core-git/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=('rdma-core-git')
 _srcname='rdma-core'
 pkgdesc='RDMA core userspace libraries and daemons'
-pkgver='r4305'
+pkgver='r4307'
 pkgrel='1'
 arch=('x86_64')
 url="https://github.com/linux-rdma/${_srcname}"
@@ -11,7 +11,7 @@ license=('GPL2' 'custom:OpenIB.org BSD (MIT variant)')
 
 depends=('libnl')
 makedepends=('git' 'cmake' 'gcc' 'libnl' 'libsystemd' 'systemd' 'pkg-config' 'ninja' 'bash' 'pandoc' 'python')
-_provides=("${pkgname[0]%-git}" 'rdma' 'ibacm' 'iwpmd' 'libibcm' 'libibumad' 'libibverbs'
+_provides=("${pkgname[0]%-git}" 'rdma' 'ibacm' 'libiwpm' 'libibcm' 'libibumad' 'libibverbs'
            'librdmacm' 'libcxgb3' 'libcxgb4' 'libmlx4' 'libmlx5' 'libmthca' 'libnes' 'libocrdma'
            'srptools')
 provides=("${_provides[@]}")

--- a/infiniband/rdma-core/PKGBUILD
+++ b/infiniband/rdma-core/PKGBUILD
@@ -5,14 +5,14 @@ _srcname='rdma-core'
 pkgdesc='RDMA core userspace libraries and daemons'
 pkgver='20.1'
 _tag="v${pkgver}"
-pkgrel='1'
+pkgrel='2'
 arch=('x86_64')
 url="https://github.com/linux-rdma/${_srcname}"
 license=('GPL2' 'custom:OpenIB.org BSD (MIT variant)')
 
 depends=('libnl')
 makedepends=('git' 'cmake' 'gcc' 'libnl' 'libsystemd' 'systemd' 'pkg-config' 'ninja' 'bash' 'pandoc' 'python')
-_provides=("${pkgname[0]%-git}" 'rdma' 'ibacm' 'iwpmd' 'libibcm' 'libibumad' 'libibverbs'
+_provides=("${pkgname[0]%-git}" 'rdma' 'ibacm' 'libiwpm' 'libibcm' 'libibumad' 'libibverbs'
            'librdmacm' 'libcxgb3' 'libcxgb4' 'libmlx4' 'libmlx5' 'libmthca' 'libnes' 'libocrdma'
            'srptools')
 provides=("${_provides[@]}")


### PR DESCRIPTION
I don't think there was ever an AUR package named iwpmd.  The package before rdma-core is libiwpm, which I've submitted an AUR merge request into rdma-core.  (No comments exist, so just merging to leave a paper trail.)

libiwpm provided:
```
   /usr/bin/iwpmd
   /usr/include/rdma/{iwarp_pm,iwpm_netlink}.h
```
rdma-core provides:
```
   /usr/bin/iwpmd
```

, along with files that weren't upstream from libiwpm, but are in rdma-core:

```
   /etc/iwpmd.conf
   /etc/rdma/modules/iwpmd.conf
   /usr/lib/systemd/service/iwpmd.service
   /usr/lib/udev/rules.d/90-iwpmd.rules
   /usr/share/man/*
```

Regarding the files not provided by rdma-core `/usr/include/rdma/{iwarp_pm,iwpm_netlink}.h`, upstream has `iwpmd/iwarp_pm*` which are deliberately not installed.  I believe these files are just some of the many header files they don't intend to be globally installed.  I'm assuming `iwpm_netlink` is no longer supported or needed.  I think these two header files not being installed is fine.