### PR TITLE
Add ethtool to depends

### DIFF
--- a/infiniband/rdma-core/PKGBUILD
+++ b/infiniband/rdma-core/PKGBUILD
@@ -10,7 +10,7 @@ arch=('x86_64')
 url="https://github.com/linux-rdma/${_srcname}"
 license=('GPL2' 'custom:OpenIB.org BSD (MIT variant)')
 
-depends=('libnl')
+depends=('libnl' 'ethtool')
 makedepends=('git' 'cmake' 'gcc' 'libnl' 'libsystemd' 'systemd' 'pkg-config' 'ninja' 'bash' 'pandoc' 'python')
 _provides=('rdma' 'ibacm' 'libiwpm' 'libibcm' 'libibumad' 'libibverbs'
            'librdmacm' 'libcxgb3' 'libcxgb4' 'libmlx4' 'libmlx5' 'libmthca' 'libnes' 'libocrdma'


### PR DESCRIPTION
Otherwise an error occurs during runtime: Can't exec "ethtool": No such file or directory at /usr/bin/rxe_cfg line 154.