### PR TITLE
Use --no-show-signature option for git log

### DIFF
--- a/i3ipc/i3ipc-glib-git/PKGBUILD
+++ b/i3ipc/i3ipc-glib-git/PKGBUILD
@@ -26,7 +26,7 @@ pkgver() {
 
     printf 'r%s.%s.%s\n' \
         "$( git rev-list --count 'HEAD' )" \
-        "$( git log --max-count='1' --pretty='format:%ct' )" \
+        "$( git log --no-show-signature --max-count='1' --pretty='format:%ct' )" \
         "$( git rev-parse --short 'HEAD' )"
 }
 

--- a/i3ipc/i3ipc-python-git/PKGBUILD
+++ b/i3ipc/i3ipc-python-git/PKGBUILD
@@ -21,7 +21,7 @@ pkgver() {
 
     printf 'r%s.%s.%s\n' \
         "$( git rev-list --count 'HEAD' )" \
-        "$( git log --max-count='1' --pretty='format:%ct' )" \
+        "$( git log --no-show-signature --max-count='1' --pretty='format:%ct' )" \
         "$( git rev-parse --short 'HEAD' )"
 }
 


### PR DESCRIPTION
This should ensure that the pkgver function works as expected even for
people who have log.showSignature set to true in their git config.

I currently get this error when building these packages:

```
==> Starting pkgver()...
==> ERROR: pkgver is not allowed to contain colons, forward slashes, hyphens or whitespace.
==> ERROR: pkgver() generated an invalid version: r328.gpg: Signature made Tue 29 Oct 2019 14:59:49 GMT
gpg:                using RSA key 4AEE18F83AFDEB23
gpg: Good signature from "GitHub (web-flow commit signing) <noreply@github.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 5DE3 E050 9C47 EA3C F04A  42D3 4AEE 18F8 3AFD EB23
1572361189.29c6f0d
```

With this change I would not have to update my gitconfig or edit the PKGBUILD on every update.