### PR TITLE
i3ipc-glib-git: Add missing 'glib2-devel' to makedepends

### DIFF
--- a/i3ipc/i3ipc-glib-git/PKGBUILD
+++ b/i3ipc/i3ipc-glib-git/PKGBUILD
@@ -14,7 +14,7 @@ optdepends=(
     'i3ipc-python: Python language bindings'
     'i3ipc-gjs: JavaScript language bindings'
 )
-makedepends=('git' 'libxcb' 'xcb-proto' 'gobject-introspection' 'gtk-doc')
+makedepends=('git' 'libxcb' 'xcb-proto' 'gobject-introspection' 'gtk-doc' 'glib2-devel')
 provides=("${pkgname[0]%-git}")
 conflicts=("${pkgname[0]%-git}")
 


### PR DESCRIPTION
Required due to new package split, as per
https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/message/FLUDH7DXL5CJNZPX4NAWKQO2QJF3PZCD/

Fails in `build()` with `/bin/sh: line 2: /usr/bin/glib-mkenums: No such file or directory` without this added dependency